### PR TITLE
README.md git clone cmd gets submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ shell, and an installed Mono framework.
 First, clone the mono-debug project:
 
 ```bash
-$ git clone https://github.com/microsoft/vscode-mono-debug
+$ git clone --recursive https://github.com/microsoft/vscode-mono-debug
 ```
 
 To build the extension vsix, run:


### PR DESCRIPTION
git clone ... --recursive to populate external/* submodules

```
Submodule 'external/debugger-libs' (https://github.com/mono/debugger-libs.git) registered for path 'external/debugger-libs'
Submodule 'external/nrefactory' (https://github.com/xamarin/NRefactory.git) registered for path 'external/nrefactory'
```